### PR TITLE
Fix update procedure

### DIFF
--- a/TFWUpdater.cpp
+++ b/TFWUpdater.cpp
@@ -26,7 +26,7 @@ bool TFWUpdater::CheckNewFirmwareAvailable()
 
 bool TFWUpdater::UpdateFirmware()
 {
-    if (WbMsw->FwUpdate((void*)WB_MSW_UPDATE_ADDRESS, FirmwareSize)) {
+    if (WbMsw->FwUpdate((uint16_t*)WB_MSW_UPDATE_ADDRESS, FirmwareSize / 2)) {
         NewFirmware = false;
         return true;
     }

--- a/TFWUpdater.cpp
+++ b/TFWUpdater.cpp
@@ -26,7 +26,7 @@ bool TFWUpdater::CheckNewFirmwareAvailable()
 
 bool TFWUpdater::UpdateFirmware()
 {
-    if (WbMsw->FwUpdate((uint16_t*)WB_MSW_UPDATE_ADDRESS, FirmwareSize / 2)) {
+    if (WbMsw->FwUpdate((uint16_t*)WB_MSW_UPDATE_ADDRESS, FirmwareSize / sizeof(uint16_t))) {
         NewFirmware = false;
         return true;
     }

--- a/TWBMSWSensor.cpp
+++ b/TWBMSWSensor.cpp
@@ -186,26 +186,29 @@ bool TWBMSWSensor::SetFwMode(void)
 
 bool TWBMSWSensor::FwWriteInfo(uint16_t* info)
 {
-    uint16_t infoData[WBMSW_FIRMWARE_INFO_SIZE / 2];
-    for (size_t i = 0; i < WBMSW_FIRMWARE_INFO_SIZE / 2; i++) {
+    uint16_t infoData[WBMSW_FIRMWARE_INFO_SIZE / sizeof(uint16_t)];
+    for (size_t i = 0; i < WBMSW_FIRMWARE_INFO_SIZE / sizeof(uint16_t); i++) {
         infoData[i] = lowByte(info[i]) << 8 | highByte(info[i]);
     }
-    return writeMultipleRegisters(Address, WBMSW_REG_FW_INFO, WBMSW_FIRMWARE_INFO_SIZE / 2, infoData);
+    return writeMultipleRegisters(Address, WBMSW_REG_FW_INFO, WBMSW_FIRMWARE_INFO_SIZE / sizeof(uint16_t), infoData);
 }
 
 bool TWBMSWSensor::FwWriteData(uint16_t* data)
 {
-    uint16_t firmwareData[WBMSW_FIRMWARE_DATA_SIZE / 2];
-    for (size_t i = 0; i < WBMSW_FIRMWARE_DATA_SIZE / 2; i++) {
+    uint16_t firmwareData[WBMSW_FIRMWARE_DATA_SIZE / sizeof(uint16_t)];
+    for (size_t i = 0; i < WBMSW_FIRMWARE_DATA_SIZE / sizeof(uint16_t); i++) {
         firmwareData[i] = lowByte(data[i]) << 8 | highByte(data[i]);
     }
-    return writeMultipleRegisters(Address, WBMSW_REG_FW_DATA, WBMSW_FIRMWARE_DATA_SIZE / 2, firmwareData);
+    return writeMultipleRegisters(Address,
+                                  WBMSW_REG_FW_DATA,
+                                  WBMSW_FIRMWARE_DATA_SIZE / sizeof(uint16_t),
+                                  firmwareData);
 }
 
 bool TWBMSWSensor::FwUpdate(uint16_t* buffer, size_t length, uint16_t timeoutMs)
 {
     // len in words, WBMSW_FIRMWARE_INFO_SIZE in bytes
-    if (length < WBMSW_FIRMWARE_INFO_SIZE / 2) {
+    if (length < WBMSW_FIRMWARE_INFO_SIZE / sizeof(uint16_t)) {
         return false;
     }
     DEBUG("FW size: ");
@@ -225,16 +228,16 @@ bool TWBMSWSensor::FwUpdate(uint16_t* buffer, size_t length, uint16_t timeoutMs)
         return false;
     }
     DEBUG("Write info\n");
-    data += WBMSW_FIRMWARE_INFO_SIZE / 2;
-    length -= WBMSW_FIRMWARE_INFO_SIZE / 2;
+    data += WBMSW_FIRMWARE_INFO_SIZE / sizeof(uint16_t);
+    length -= WBMSW_FIRMWARE_INFO_SIZE / sizeof(uint16_t);
 
     DEBUG("Write data\n");
     while (length) {
         if (!FwWriteData(data)) {
             return false;
         }
-        data += WBMSW_FIRMWARE_DATA_SIZE / 2;
-        length -= WBMSW_FIRMWARE_DATA_SIZE / 2;
+        data += WBMSW_FIRMWARE_DATA_SIZE / sizeof(uint16_t);
+        length -= WBMSW_FIRMWARE_DATA_SIZE / sizeof(uint16_t);
     }
 
     DEBUG("Write finish\n");

--- a/TWBMSWSensor.cpp
+++ b/TWBMSWSensor.cpp
@@ -1,6 +1,7 @@
 
 #include "TWBMSWSensor.h"
 #include "DebugOutput.h"
+#include "WbMsw.h"
 
 #define WBMSW_REG_TEMPERATURE 0x0004
 #define WBMSW_REG_HUMIDITY 0x0005
@@ -74,7 +75,7 @@ bool TWBMSWSensor::GetFwVersion(uint16_t& version)
 
     size_t i = 0;
     size_t j = 0;
-    uint8_t semanticVersion[2]={0};
+    uint8_t semanticVersion[2] = {0};
     while ((i < WBMSW_VERSION_NUMBER_LENGTH) && (j < sizeof(semanticVersion))) {
         if (versionStr[i] == '.') {
             j++;
@@ -183,49 +184,57 @@ bool TWBMSWSensor::SetFwMode(void)
     return writeSingleRegisters(Address, WBMSW_REG_FW_MODE, 1);
 }
 
-bool TWBMSWSensor::FwWriteInfo(uint8_t* info)
+bool TWBMSWSensor::FwWriteInfo(uint16_t* info)
 {
-    return writeMultipleRegisters(Address, WBMSW_REG_FW_INFO, WBMSW_FIRMWARE_INFO_SIZE / 2, info);
+    uint16_t infoData[WBMSW_FIRMWARE_INFO_SIZE / 2];
+    for (size_t i = 0; i < WBMSW_FIRMWARE_INFO_SIZE / 2; i++) {
+        infoData[i] = lowByte(info[i]) << 8 | highByte(info[i]);
+    }
+    return writeMultipleRegisters(Address, WBMSW_REG_FW_INFO, WBMSW_FIRMWARE_INFO_SIZE / 2, infoData);
 }
 
-bool TWBMSWSensor::FwWriteData(uint8_t* data)
+bool TWBMSWSensor::FwWriteData(uint16_t* data)
 {
-    return writeMultipleRegisters(Address, WBMSW_REG_FW_DATA, WBMSW_FIRMWARE_DATA_SIZE / 2, data);
+    uint16_t firmwareData[WBMSW_FIRMWARE_DATA_SIZE / 2];
+    for (size_t i = 0; i < WBMSW_FIRMWARE_DATA_SIZE / 2; i++) {
+        firmwareData[i] = lowByte(data[i]) << 8 | highByte(data[i]);
+    }
+    return writeMultipleRegisters(Address, WBMSW_REG_FW_DATA, WBMSW_FIRMWARE_DATA_SIZE / 2, firmwareData);
 }
 
-bool TWBMSWSensor::FwUpdate(const void* buffer, size_t len, uint16_t timeoutMs)
+bool TWBMSWSensor::FwUpdate(uint16_t* buffer, size_t length, uint16_t timeoutMs)
 {
-    uint8_t* data;
-    if (len < WBMSW_FIRMWARE_INFO_SIZE) {
+    // len in words, WBMSW_FIRMWARE_INFO_SIZE in bytes
+    if (length < WBMSW_FIRMWARE_INFO_SIZE / 2) {
         return false;
     }
     DEBUG("FW size: ");
-    DEBUG(len);
+    DEBUG(length * 2);
     DEBUG("\n");
 
     if (!this->SetFwMode()) {
+        DEBUG("ERROR Supposed to be alive, but found in bootloader");
         return false;
     }
-    DEBUG("Wait ");
-    DEBUG(timeoutMs);
-    DEBUG(" ms\n");
 
     delay(timeoutMs);
-    data = (uint8_t*)buffer;
+    uint16_t* data = buffer;
+
     if (!this->FwWriteInfo(data)) {
+        DEBUG("ERROR Unsuccesful info block write");
         return false;
     }
     DEBUG("Write info\n");
-    data += WBMSW_FIRMWARE_INFO_SIZE;
-    len -= WBMSW_FIRMWARE_INFO_SIZE;
+    data += WBMSW_FIRMWARE_INFO_SIZE / 2;
+    length -= WBMSW_FIRMWARE_INFO_SIZE / 2;
 
     DEBUG("Write data\n");
-    while (len) {
+    while (length) {
         if (!FwWriteData(data)) {
             return false;
         }
-        data += WBMSW_FIRMWARE_DATA_SIZE;
-        len -= WBMSW_FIRMWARE_DATA_SIZE;
+        data += WBMSW_FIRMWARE_DATA_SIZE / 2;
+        length -= WBMSW_FIRMWARE_DATA_SIZE / 2;
     }
 
     DEBUG("Write finish\n");

--- a/TWBMSWSensor.h
+++ b/TWBMSWSensor.h
@@ -31,7 +31,7 @@ public:
     bool GetVoc(int64_t& voc);
     bool GetNoiseLevel(int64_t& noiseLevel);
     bool GetMotion(int64_t& motion);
-    bool FwUpdate(const void* buffer, size_t len, uint16_t timeoutMs = 2000);
+    bool FwUpdate(uint16_t* buffer, size_t length, uint16_t timeoutMs = 2000);
 
     bool GetTemperatureAvailability(TWBMSWSensor::Availability& availability);
     bool GetHumidityAvailability(TWBMSWSensor::Availability& availability);
@@ -43,8 +43,8 @@ public:
 
 private:
     bool SetFwMode(void);
-    bool FwWriteInfo(uint8_t* info);
-    bool FwWriteData(uint8_t* info);
+    bool FwWriteInfo(uint16_t* info);
+    bool FwWriteData(uint16_t* info);
     TWBMSWSensor::Availability ConvertAvailability(uint16_t availability) const;
     bool ReadAvailabilityRegister(TWBMSWSensor::Availability& availability, uint16_t registerAddress);
     uint8_t Address;

--- a/WbMsw.h
+++ b/WbMsw.h
@@ -1,7 +1,7 @@
 #ifndef WB_MSW_H
 #define WB_MSW_H
 
-#define WB_MSW_TIMEOUT 1000
+#define WB_MSW_TIMEOUT 2000
 #define WB_MSW_ON 255
 #define WB_MSW_OFF 0
 
@@ -79,5 +79,8 @@
 #define WB_MSW_UART_MODE SERIAL_8N2
 #define WB_MSW_UART_RX 8 // Z-Uno receiver pin
 #define WB_MSW_UART_TX 7 // Z-uno transmitter pin
+
+#define WB_MSW_UART_BOOTLOADER_BAUD 9600
+#define WB_MSW_UART_BOOTLOADER_MODE SERIAL_8N2
 
 #endif // WB_MSW_H

--- a/WbMsw.ino
+++ b/WbMsw.ino
@@ -19,7 +19,7 @@ ZUNO_ENABLE(
 		ZUNO_CUSTOM_OTA_OFFSET=0x10000 // 64 kB
 		/* Additional OTA firmwares count*/
 		ZUNO_EXT_FIRMWARES_COUNT=1
-		SKETCH_VERSION=0x0102
+		SKETCH_VERSION=0x0103
 		/* Firmware descriptor pointer */
 		ZUNO_EXT_FIRMWARES_DESCR_PTR=&g_OtaDesriptor
 		LOGGING_DBG // Comment out if debugging information is not needed
@@ -72,6 +72,9 @@ static void SystemEvent(ZUNOSysEvent_t* ev)
         // A new firmware image for the second chip from the Z-Wave controller has arrived
         case ZUNO_SYS_EVENT_OTA_IMAGE_READY:
             if (ev->params[0] == 0) {
+                DEBUG("NEW FIRMWARE AVAILABLE, SIZE=");
+                DEBUG(ev->params[1]);
+                DEBUG(" BYTES\n");
                 FwUpdater.NewFirmwareNotification(ev->params[1]);
             }
             break;
@@ -86,6 +89,8 @@ static void UpdateParameterValue(size_t paramNumber, int32_t value)
 // The function is called at the start of the sketch
 void setup()
 {
+    // Set system event handler (needed for firmware updates)
+    zunoAttachSysHandler(ZUNO_HANDLER_SYSEVENT, 0, (void*)&SystemEvent);
     ZUnoState = TZUnoState::ZUNO_SCAN_ADDRESS_INITIALIZE;
 }
 // Main loop
@@ -164,8 +169,6 @@ void loop()
                 }
                 // Bind handlers for channels fields
                 ZwaveSensor.SetChannelHandlers();
-                // Set system event handler (needed for firmware updates)
-                zunoAttachSysHandler(ZUNO_HANDLER_SYSEVENT, 0, (void*)&SystemEvent);
                 // Set parameter changing event handler (needed for firmware updates)
                 zunoAttachSysHandler(ZUNO_HANDLER_ZW_CFG, 0, (void*)&UpdateParameterValue);
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-zwave-msw (1.3) stable; urgency=medium
+
+  * Fix update procedure
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Fri, 16 Dec 2022 12:50:42 +0300
+
 wb-zwave-msw (1.2) stable; urgency=medium
 
   * Add sensors availability support


### PR DESCRIPTION
### Описание
Поправлена процедура прошивки так, чтобы в качестве единицы данных использовать uint16_t в соответствии с размером модбас-регистров.

### Проверки
- [x] Проверены все [тест-кейсы](https://github.com/wirenboard/wb-zwave-msw/blob/master/test_cases.md)
- [x] Поднята версия в файле changelog
- [x] Поднята версия в определении ZUNO_ENABLE
