### PR TITLE
Fix motion callback

### DIFF
--- a/TZWAVESensor.cpp
+++ b/TZWAVESensor.cpp
@@ -149,8 +149,8 @@ bool TZWAVESensor::ChannelsInitialize()
                                   WB_MSW_CONFIG_PARAMETER_MOTION_THRESHOLD,
                                   WB_MSW_CONFIG_PARAMETER_MOTION_INVERT,
                                   WbMsw,
-                                  &TWBMSWSensor::GetNoiseLevel,
-                                  &TWBMSWSensor::GetNoiseLevelAvailability);
+                                  &TWBMSWSensor::GetMotion,
+                                  &TWBMSWSensor::GetMotionAvailability);
 
     bool unknownSensorsLeft = false;
 

--- a/WbMsw.ino
+++ b/WbMsw.ino
@@ -19,11 +19,13 @@ ZUNO_ENABLE(
 		ZUNO_CUSTOM_OTA_OFFSET=0x10000 // 64 kB
 		/* Additional OTA firmwares count*/
 		ZUNO_EXT_FIRMWARES_COUNT=1
-		SKETCH_VERSION=0x0103
+		SKETCH_VERSION=0x0104
 		/* Firmware descriptor pointer */
 		ZUNO_EXT_FIRMWARES_DESCR_PTR=&g_OtaDesriptor
-		LOGGING_DBG // Comment out if debugging information is not needed
+		//LOGGING_DBG // Comment out if debugging information is not needed
 					// Debugging information being printed with RTOS system console output to UART0 (TX0) by default
+        DBG_CONSOLE_PIN=0xFF
+        //DBG_CONSOLE_BAUDRATE=115200
 		//LOGGING_UART=Serial
 
 	);
@@ -72,10 +74,10 @@ static void SystemEvent(ZUNOSysEvent_t* ev)
         // A new firmware image for the second chip from the Z-Wave controller has arrived
         case ZUNO_SYS_EVENT_OTA_IMAGE_READY:
             if (ev->params[0] == 0) {
-                DEBUG("NEW FIRMWARE AVAILABLE, SIZE=");
-                DEBUG(ev->params[1]);
-                DEBUG(" BYTES\n");
                 FwUpdater.NewFirmwareNotification(ev->params[1]);
+                DEBUG("NEW FIRMWARE AVAILALBE, SIZE ");
+                DEBUG(ev->params[1]);
+                DEBUG("\n");
             }
             break;
     }
@@ -89,8 +91,6 @@ static void UpdateParameterValue(size_t paramNumber, int32_t value)
 // The function is called at the start of the sketch
 void setup()
 {
-    // Set system event handler (needed for firmware updates)
-    zunoAttachSysHandler(ZUNO_HANDLER_SYSEVENT, 0, (void*)&SystemEvent);
     ZUnoState = TZUnoState::ZUNO_SCAN_ADDRESS_INITIALIZE;
 }
 // Main loop
@@ -169,6 +169,8 @@ void loop()
                 }
                 // Bind handlers for channels fields
                 ZwaveSensor.SetChannelHandlers();
+                // Set system event handler (needed for firmware updates)
+                zunoAttachSysHandler(ZUNO_HANDLER_SYSEVENT, 0, (void*)&SystemEvent);
                 // Set parameter changing event handler (needed for firmware updates)
                 zunoAttachSysHandler(ZUNO_HANDLER_ZW_CFG, 0, (void*)&UpdateParameterValue);
 

--- a/WbMsw.ino
+++ b/WbMsw.ino
@@ -74,10 +74,10 @@ static void SystemEvent(ZUNOSysEvent_t* ev)
         // A new firmware image for the second chip from the Z-Wave controller has arrived
         case ZUNO_SYS_EVENT_OTA_IMAGE_READY:
             if (ev->params[0] == 0) {
-                FwUpdater.NewFirmwareNotification(ev->params[1]);
-                DEBUG("NEW FIRMWARE AVAILALBE, SIZE ");
+                DEBUG("NEW FIRMWARE AVAILABLE, SIZE=");
                 DEBUG(ev->params[1]);
-                DEBUG("\n");
+                DEBUG(" BYTES\n");
+                FwUpdater.NewFirmwareNotification(ev->params[1]);
             }
             break;
     }
@@ -91,6 +91,8 @@ static void UpdateParameterValue(size_t paramNumber, int32_t value)
 // The function is called at the start of the sketch
 void setup()
 {
+    // Set system event handler (needed for firmware updates)
+    zunoAttachSysHandler(ZUNO_HANDLER_SYSEVENT, 0, (void*)&SystemEvent);
     ZUnoState = TZUnoState::ZUNO_SCAN_ADDRESS_INITIALIZE;
 }
 // Main loop
@@ -169,8 +171,6 @@ void loop()
                 }
                 // Bind handlers for channels fields
                 ZwaveSensor.SetChannelHandlers();
-                // Set system event handler (needed for firmware updates)
-                zunoAttachSysHandler(ZUNO_HANDLER_SYSEVENT, 0, (void*)&SystemEvent);
                 // Set parameter changing event handler (needed for firmware updates)
                 zunoAttachSysHandler(ZUNO_HANDLER_ZW_CFG, 0, (void*)&UpdateParameterValue);
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-zwave-msw (1.4) stable; urgency=medium
+
+  * Fix motion callback
+  * Disable debug output
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Fri, 16 Dec 2022 12:50:42 +0300
+
 wb-zwave-msw (1.3) stable; urgency=medium
 
   * Fix update procedure


### PR DESCRIPTION
### Описание
Была ошибка в коллбэке чтения с датчика движения - исправлено. Выключила по умолчанию отладочный вывод.

### Проверки
- [x] Проверены все [тест-кейсы](https://github.com/wirenboard/wb-zwave-msw/blob/master/test_cases.md)
- [x] Поднята версия в файле changelog
- [x] Поднята версия в определении ZUNO_ENABLE
